### PR TITLE
chore: added support of go1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        gover: [1.18, 1.19]
+        gover: ['~1.18', '~1.19', '~1.20']
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,40 @@ This project is to develops sample implementations using sabi framework.
 This is a private project to verify usability of sabi framework for command line program, and this target platform is only macOS.
 
 
+### Actual test results for each Go version:
+
+```
+% gvm-fav
+Now using version go1.18.10
+go version go1.18.10 darwin/amd64
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/lib	0.131s	coverage: 87.5% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/tty	0.159s	coverage: 56.5% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/whoami	0.221s	coverage: 69.0% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/yes	0.138s	coverage: 55.6% of statements
+
+Now using version go1.19.5
+go version go1.19.5 darwin/amd64
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/lib	0.132s	coverage: 87.5% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/tty	0.168s	coverage: 56.5% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/whoami	0.232s	coverage: 69.0% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/yes	0.141s	coverage: 55.6% of statements
+
+Now using version go1.20
+go version go1.20 darwin/amd64
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/lib	0.142s	coverage: 87.5% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/tty	0.196s	coverage: 56.5% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/whoami	0.297s	coverage: 69.0% of statements
+ok  	github.com/sttk-go/sabi-sample-gnu-coreutils/yes	0.400s	coverage: 55.6% of statements
+
+Back to go1.20
+Now using version go1.20
+%
+```
+
+
 ## License
 
-Copyright (C) 2022 Takayuki Sato
+Copyright (C) 2022-2023 Takayuki Sato
 
 This program is free software under GPLv3 License.<br>
 See the file LICENSE in this distribution for more details.


### PR DESCRIPTION
This PR adds go 1.20 to the actual test results in `README.md` and the target versions of CI, since [Go 1.20 was released](https://golang.google.cn/blog/go1.20).