### PR TITLE
update!: upgraded sabi to v0.2, and replaced sabi.ErrBy to sabi.NewErr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.8.1
-	github.com/sttk-go/sabi v0.1.0
+	github.com/sttk-go/sabi v0.2.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/sttk-go/sabi v0.1.0 h1:+JxoXajwRjLXkDT6DWXfWf+6GVDALxALSDlLDIBxJBY=
-github.com/sttk-go/sabi v0.1.0/go.mod h1:YcP+oW3jRInzYmFIKXt32gnfAX5PewyNmkCZSbpEo7A=
+github.com/sttk-go/sabi v0.2.0 h1:eXyNcUmv54Kg3BIUOdrk3jNCXvFLp/MEvQriI1NBOwI=
+github.com/sttk-go/sabi v0.2.0/go.mod h1:YcP+oW3jRInzYmFIKXt32gnfAX5PewyNmkCZSbpEo7A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lib/os-dax.go
+++ b/lib/os-dax.go
@@ -51,7 +51,7 @@ func (conn *OsDaxConn) GetTtyName(fd int) (string, sabi.Err) {
 	}
 
 	// errno = 9:EBADF | 19:ENODEV | 25:ENOTTY | 34:ERANGE
-	return "", sabi.ErrBy(FailToGetTtyName{Errno: errno})
+	return "", sabi.NewErr(FailToGetTtyName{Errno: errno})
 }
 
 type OsDax struct {

--- a/tty/arg-dax.go
+++ b/tty/arg-dax.go
@@ -33,7 +33,7 @@ func (dax ArgDax) GetMode() (int, sabi.Err) {
 
 		default:
 			mode = MODE_ERROR
-			err = sabi.ErrBy(InvalidOption{Option: arg})
+			err = sabi.NewErr(InvalidOption{Option: arg})
 		}
 	}
 

--- a/tty/console-dax.go
+++ b/tty/console-dax.go
@@ -22,7 +22,7 @@ There is NO WARRANTY, to the extent permitted by law.
 Written by Takayuki Sato.
 `)
 	if err != nil {
-		return sabi.ErrBy(FailToPrint{})
+		return sabi.NewErr(FailToPrint{})
 	}
 	return sabi.Ok()
 }
@@ -36,7 +36,7 @@ Print the file name of the terminal connected to standard input.
       --version     output version information and exit
 `)
 	if err != nil {
-		return sabi.ErrBy(FailToPrint{})
+		return sabi.NewErr(FailToPrint{})
 	}
 	return sabi.Ok()
 }
@@ -44,7 +44,7 @@ Print the file name of the terminal connected to standard input.
 func (dax ConsoleDax) PrintTtyName(ttyname string) sabi.Err {
 	_, err := fmt.Println(ttyname)
 	if err != nil {
-		return sabi.ErrBy(FailToPrint{})
+		return sabi.NewErr(FailToPrint{})
 	}
 	return sabi.Ok()
 }

--- a/tty/os-user-dax.go
+++ b/tty/os-user-dax.go
@@ -27,7 +27,7 @@ func (dax OsUserDax) GetStdinTtyName() (string, sabi.Err) {
 	case lib.FailToGetTtyName:
 		switch err.Reason().(lib.FailToGetTtyName).Errno {
 		case lib.ENOTTY:
-			return ttyname, sabi.ErrBy(StdinIsNotTty{})
+			return ttyname, sabi.NewErr(StdinIsNotTty{})
 		}
 	}
 

--- a/tty/tty_test.go
+++ b/tty/tty_test.go
@@ -17,7 +17,7 @@ func newMapDax(m map[string]any) mapDax {
 func (dax mapDax) GetMode() (int, sabi.Err) {
 	switch dax.m["mode"].(int) {
 	case MODE_ERROR:
-		return MODE_ERROR, sabi.ErrBy(InvalidOption{Option: "--opt"})
+		return MODE_ERROR, sabi.NewErr(InvalidOption{Option: "--opt"})
 	default:
 		return dax.m["mode"].(int), sabi.Ok()
 	}
@@ -28,9 +28,9 @@ type TtyError struct{}
 func (dax mapDax) GetStdinTtyName() (string, sabi.Err) {
 	switch dax.m["error"] {
 	case "notty":
-		return "not a tty", sabi.ErrBy(StdinIsNotTty{})
+		return "not a tty", sabi.NewErr(StdinIsNotTty{})
 	case "ttyError":
-		return "tty error", sabi.ErrBy(TtyError{})
+		return "tty error", sabi.NewErr(TtyError{})
 	default:
 		return dax.m["ttyname"].(string), sabi.Ok()
 	}
@@ -38,7 +38,7 @@ func (dax mapDax) GetStdinTtyName() (string, sabi.Err) {
 
 func (dax mapDax) PrintTtyName(ttyname string) sabi.Err {
 	if dax.m["error"] == "failToPrint" {
-		return sabi.ErrBy(FailToPrint{})
+		return sabi.NewErr(FailToPrint{})
 	}
 	dax.m["print"] = ttyname
 	return sabi.Ok()


### PR DESCRIPTION
This PR upgrades sabi framework to v0.2. Because sabi v0.2 replaces `sabi.ErrBy` function to `sabi.NewErr`, this PR replaces all `sabi.ErrBy` functions in this project to `sabi.NewErr` accordingly.